### PR TITLE
Better `[profile.release]` for `Cargo.toml`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ serde_json = "1.0.85"
 serde = { version = "1.0.145", features = ["derive"] }
 
 [profile.release]
-opt-level = 3
 lto = true
 codegen-units = 1
+strip = true
 
 [patch.crates-io]
 steamy-vdf = { git = "https://github.com/icewind1991/steamy" }


### PR DESCRIPTION
`opt-level = 3` is redundant, since the `release` profile already has a default `opt-level` of `3`.

Symbol stripping might not be something you want, but it tends to shrink binary size significantly.