### PR TITLE
Fix and improve logging.

### DIFF
--- a/astro_modloader/src/logging.rs
+++ b/astro_modloader/src/logging.rs
@@ -7,6 +7,7 @@ use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 
 #[derive(Debug)]
 struct SimpleLogger {
+    // Synchronize log entries
     file: Mutex<BufWriter<fs::File>>,
 }
 
@@ -18,6 +19,7 @@ impl SimpleLogger {
     }
 
     fn lock<T>(&self, f: impl FnOnce(&mut BufWriter<fs::File>) -> T) -> T {
+        // Ignore log mutex poison
         let mut guard = match self.file.lock() {
             Ok(guard) => guard,
             Err(err) => err.into_inner(),
@@ -91,6 +93,7 @@ fn get_logger() -> &'static SimpleLogger {
     static LOGGER: OnceLock<SimpleLogger> = OnceLock::new();
     LOGGER.get_or_init(|| {
         SimpleLogger::new(
+            // Open file
             fs::OpenOptions::new()
                 .write(true)
                 .create(true)

--- a/astro_modloader/src/main.rs
+++ b/astro_modloader/src/main.rs
@@ -246,4 +246,6 @@ fn main() {
     let config = AstroGameConfig;
 
     unreal_mod_manager::run(config);
+
+    logging::flush();
 }


### PR DESCRIPTION
I fixed the possible undefined behavior in the logging system (`static mut` is evil) as well as the racy behavior when logging rapidly on multiple threads. I also improved logging performance by writing to a `BufWriter` instead of writing directly to the log file.

Logging rapidly on multiple threads will block some of the threads while another is logging; this could be fixed by logging to individual string buffers and putting them in a concurrent queue, but that's a lot of allocations and copying, so it's probably not worth it.