### PR TITLE
BaseGameInitialKnownItemList backwards compatibility hotfix

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -11,7 +11,8 @@ accepted = [
     "CC0-1.0",
     "MPL-2.0",
     "BSD-3-Clause",
-    "ISC"
+    "ISC",
+    "Unicode-3.0"
 ]
 
 [unreal_asset.clarify]


### PR DESCRIPTION
This pull request modifies the mod integrator to copy all `/Game/Items/ItemTypes/MasterItemList` item list entries to also be integrated into `/Game/Items/ItemTypes/BaseGameInitialKnownItemList`, if a given mod does not explicitly specify entries for `/Game/Items/ItemTypes/BaseGameInitialKnownItemList` already.

Without this change, any mod that does not explicitly add any given new item into the `/Game/Items/ItemTypes/BaseGameInitialKnownItemList` list will not have that item visible in the research catalog on new saves, as it will not be considered a "known item." My understanding is that this is a relatively new and unknown issue. So, this hotfix is necessary to ensure that nearly every single current mod that currently adds items to the game is compatible with the latest version of the game. This hotfix also rectifies the issue for any pre-existing saves that may currently suffer from this issue.

While, strictly speaking, mod authors should simply be required to update their mods to be compatible for the latest version, the sudden and unexpected discontinuation of the astroneermods.space website means that it seems that many mods that were previously available on the website are as of yet not actively maintained. While I have considered simply privately modifying the metadata for the mods on my own archive of the website to rectify this issue (https://atenfyr.com/ams-archive/), I am hesitant to make precedent of this, as I am more interested in historical preservation than I am in personally actively maintaining the mods. So, this hot-fix allows existing mods to work on the latest version without maintenance for a little extra time, until such time that they may be maintained again, if ever.